### PR TITLE
WIP: chatbox: Add support for copy-pasting chat messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,7 @@ Makefile.in
 /ChatboxService.h
 /data/com.endlessm.Coding.Chatbox.data.gresource
 /data/com.endlessm.Coding.Chatbox.service
+/lib/ChatboxPrivate-1.0.gir
+/lib/ChatboxPrivate-1.0.typelib
 /src/com.endlessm.Coding.Chatbox
 /src/com.endlessm.Coding.Chatbox.src.gresource

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = lib
+
 # Resources
 resource_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/src --sourcedir=$(builddir)/src --generate-dependencies $(srcdir)/src/com.endlessm.Coding.Chatbox.src.gresource.xml)
 app_resource_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/data --sourcedir=$(builddir)/data --generate-dependencies $(srcdir)/data/com.endlessm.Coding.Chatbox.data.gresource.xml)

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ AC_PATH_PROG([GJS],[gjs])
 
 # Checks for libraries.
 PKG_CHECK_MODULES(CODING_CHATBOX, [glib-2.0 gio-2.0 gobject-2.0 gio-unix-2.0 gtk+-3.0])
+PKG_CHECK_MODULES(CODING_CHATBOX_PRIVATE, [glib-2.0 gio-2.0 gtk+-3.0 gdk-3.0])
 
 # Checks for header files.
 
@@ -31,5 +32,10 @@ PKG_CHECK_MODULES(CODING_CHATBOX, [glib-2.0 gio-2.0 gobject-2.0 gio-unix-2.0 gtk
 
 # Substitute variables
 AC_SUBST(GLIB_COMPILE_RESOURCES)
-AC_CONFIG_FILES([Makefile])
+
+AC_CONFIG_FILES([
+Makefile
+lib/Makefile
+])
+
 AC_OUTPUT

--- a/data/chat-bubble-container.ui
+++ b/data/chat-bubble-container.ui
@@ -7,12 +7,17 @@
       <class name="chatbox-bubble"/>
     </style>
     <child>
-      <object class="GtkBox" id="inner-box">
-        <property name="width_request">250</property>
+      <object class="GtkEventBox" id="event-box">
         <property name="visible">true</property>
-        <property name="margin">20</property>
         <child>
-          <placeholder/>
+          <object class="GtkBox" id="inner-box">
+            <property name="width_request">250</property>
+            <property name="visible">true</property>
+            <property name="margin">20</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
         </child>
       </object>
     </child>

--- a/debian/coding-chatbox.install
+++ b/debian/coding-chatbox.install
@@ -1,3 +1,4 @@
 debian/tmp/usr/bin/com.endlessm.Coding.Chatbox
+debian/tmp/usr/lib/com.endlessm.Coding.Chatbox
 debian/tmp/usr/share/com.endlessm.Coding.Chatbox
 debian/tmp/usr/share/applications/com.endlessm.Coding.Chatbox.desktop

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,0 +1,43 @@
+# Private library
+chatbox_private_sources = \
+	chatbox-utils.c \
+	chatbox-utils.h \
+	$(NULL)
+
+pkglib_LTLIBRARIES = libcoding_chatbox_private-1.0.la
+libcoding_chatbox_private_1_0_la_SOURCES = \
+	$(chatbox_private_sources) \
+	$(NULL)
+libcoding_chatbox_private_1_0_la_CFLAGS = $(CODING_CHATBOX_PRIVATE_CFLAGS)
+libcoding_chatbox_private_1_0_la_LIBADD = $(CODING_CHATBOX_PRIVATE_LIBS)
+libcoding_chatbox_private_1_0_la_LDFLAGS = -avoid-version
+
+# GObject-Introspection support
+include $(INTROSPECTION_MAKEFILE)
+INTROSPECTION_GIRS = $(NULL)
+INTROSPECTION_SCANNER_ARGS = --add-include-path=$(srcdir) --warn-all
+INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir)
+
+girdir = $(pkgdatadir)/gir-1.0
+gir_DATA = $(INTROSPECTION_GIRS)
+
+typelibdir = $(pkglibdir)/girepository-1.0
+typelib_DATA = $(gir_DATA:.gir=.typelib)
+
+if HAVE_INTROSPECTION
+
+ChatboxPrivate-1.0.gir: $(chatbox_private_sources) libcoding_chatbox_private-1.0.la Makefile
+ChatboxPrivate_1_0_gir_NAMESPACE = ChatboxPrivate
+ChatboxPrivate_1_0_gir_INCLUDES = GObject-2.0 Gio-2.0 Gtk-3.0 Gdk-3.0
+ChatboxPrivate_1_0_gir_CFLAGS = $(INCLUDES) $(CODING_CHATBOX_PRIVATE_CFLAGS)
+ChatboxPrivate_1_0_gir_LIBS = libcoding_chatbox_private-1.0.la
+ChatboxPrivate_1_0_gir_FILES = $(libcoding_chatbox_private_1_0_la_SOURCES)
+ChatboxPrivate_1_0_gir_SCANNERFLAGS = --symbol-prefix=chatbox --identifier-prefix=Chatbox
+INTROSPECTION_GIRS += ChatboxPrivate-1.0.gir
+
+CLEANFILES = \
+	$(gir_DATA) \
+	$(typelib_DATA) \
+	$(NULL)
+
+endif

--- a/lib/chatbox-utils.c
+++ b/lib/chatbox-utils.c
@@ -1,0 +1,72 @@
+/*
+ * chatbox-utils.c
+ *
+ * This is a small helper module to copy a file URI into the clipboard, since
+ * Gtk.Clipboard.set_with_data is not exposed to GObject-Introspection.
+ *
+ */
+
+#include <assert.h>
+#include <gio/gio.h>
+#include <gtk/gtk.h>
+#include <gdk/gdk.h>
+#include <glib.h>
+
+/* Values for GtkSelection-related "info" fields */
+enum {
+  SELECTION_TEXT = 0,
+  SELECTION_URI
+};
+
+static void
+copy_file_get_callback (GtkClipboard      *clipboard,
+                        GtkSelectionData  *selection_data,
+                        guint             info,
+                        gpointer          data)
+{
+  GFile *file = data;
+
+  if (info == SELECTION_URI) {
+    char **uris = g_new0 (char *, 2);
+    uris[0] = g_file_get_uri (file);
+    gtk_selection_data_set_uris (selection_data, uris);
+    g_strfreev (uris);
+  } else {
+    char *parse_name = g_file_get_parse_name (file);
+    gtk_selection_data_set_text (selection_data, parse_name, -1);
+    g_free (parse_name);
+  }
+}
+
+static void
+copy_file_clear_callback (GtkClipboard *clipboard,
+                          gpointer     data)
+{
+  GFile *file = data;
+  g_object_unref (file);
+}
+
+void
+chatbox_utils_copy_file_to_clipboard (GtkWidget *widget,
+                                      GFile     *file)
+{
+  GtkClipboard *clipboard;
+  GtkTargetList *target_list;
+  GtkTargetEntry *targets;
+  int n_targets;
+
+  clipboard = gtk_widget_get_clipboard (widget, GDK_SELECTION_CLIPBOARD);
+
+  target_list = gtk_target_list_new (NULL, 0);
+  gtk_target_list_add_text_targets (target_list, SELECTION_TEXT);
+  gtk_target_list_add_uri_targets (target_list, SELECTION_URI);
+  targets = gtk_target_table_new_from_list (target_list, &n_targets);
+  gtk_target_list_unref (target_list);
+
+  gtk_clipboard_set_with_data (clipboard, targets, n_targets,
+                               copy_file_get_callback,
+                               copy_file_clear_callback,
+                               g_object_ref (file));
+
+  gtk_target_table_free (targets, n_targets);
+}

--- a/lib/chatbox-utils.h
+++ b/lib/chatbox-utils.h
@@ -1,0 +1,16 @@
+/*
+ * chatbox-utils.h
+ *
+ * This is a small helper module to copy a file URI into the clipboard, since
+ * Gtk.Clipboard.set_with_data is not exposed to GObject-Introspection.
+ *
+ */
+
+#ifndef _CHATBOX_UTILS_H
+#define _CHATBOX_UTILS_H
+
+#include <gtk/gtk.h>
+
+void chatbox_utils_copy_file_to_clipboard (GtkWidget *widget, GFile *file);
+
+#endif

--- a/src/main.js
+++ b/src/main.js
@@ -242,11 +242,28 @@ const CodingChatboxContactListItem = new Lang.Class({
     }
 });
 
+
+// createCopyPopover
+//
+// Creates a popover copy button which invokes the specified
+// callback when the button is clicked
+function createCopyPopover(forWidget, callback) {
+    let popover = new Gtk.Popover({ relative_to: forWidget });
+    // TODO: make this translatable
+    let button = new Gtk.Button({
+        label: 'Copy',
+        visible: true
+    });
+    button.connect('clicked', callback);
+    popover.add(button);
+    return popover;
+}
+
 const CodingChatboxChatBubbleContainer = new Lang.Class({
     Name: 'CodingChatboxChatBubbleContainer',
     Extends: Gtk.Box,
     Template: 'resource:///com/endlessm/Coding/Chatbox/chat-bubble-container.ui',
-    Children: ['inner-box'],
+    Children: ['inner-box', 'event-box'],
     Properties: {
         'content': GObject.ParamSpec.object('content',
                                             '',
@@ -263,6 +280,10 @@ const CodingChatboxChatBubbleContainer = new Lang.Class({
 
     _init: function(params) {
         this.parent(params);
+        this._popover = createCopyPopover(this, Lang.bind(this, function() {
+            this.content.copyToClipboard();
+            this._popover.hide();
+        }));
 
         let [margin_prop, halign] = params.by_user ? ['margin-end', Gtk.Align.END] :
                                                      ['margin-start', Gtk.Align.START];
@@ -274,6 +295,18 @@ const CodingChatboxChatBubbleContainer = new Lang.Class({
             this.get_style_context().add_class('by-user');
 
         this.inner_box.pack_start(this.content, false, false, 0);
+        this.event_box.add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
+                                  Gdk.EventMask.BUTTON_RELEASE_MASK);
+
+        this.event_box.connect('button-press-event', Lang.bind(this, function(btn, event) {
+            if (!this.content.supportsCopyPaste())
+                return;
+
+            if (event.get_button()[1] === Gdk.BUTTON_SECONDARY) {
+                // Secondary button pressed. Show popover with copy option
+                this._popover.show();
+            }
+        }));
     },
 
     set content(val) {

--- a/src/views.js
+++ b/src/views.js
@@ -6,6 +6,7 @@
 // The views for chatbox content.
 //
 
+const ChatboxPrivate = imports.gi.ChatboxPrivate;
 const Gdk = imports.gi.Gdk;
 const GObject = imports.gi.GObject;
 const Gio = imports.gi.Gio;
@@ -22,6 +23,13 @@ const ChatboxMessageView = new Lang.Interface({
     GTypeName: 'Gjs_ChatboxMessageView',
 
     focused: function() {
+    },
+
+    copyToClipboard: function() {
+    },
+
+    supportsCopyPaste: function() {
+        return false;
     }
 });
 
@@ -46,6 +54,14 @@ const TextChatboxMessageView = new Lang.Class({
         this.state.bind_property('text', this, 'label',
                                  GObject.BindingFlags.DEFAULT |
                                  GObject.BindingFlags.SYNC_CREATE);
+    },
+
+    copyToClipboard: function() {
+        this.get_clipbpard().set_text(this.state.text, -1);
+    },
+
+    supportsCopyPaste: function() {
+        return true;
     }
 });
 
@@ -154,5 +170,13 @@ const AttachmentChatboxMessageView = new Lang.Class({
         this.attachment_desc.label = this.state.desc;
         this.attachment_icon.set_from_gicon(getIconForFile(this.state.path),
                                             Gtk.IconSize.DIALOG);
+    },
+
+    copyToClipboard: function() {
+        ChatboxPrivate.utils_copy_file_to_clipboard(this, this.state.path);
+    },
+
+    supportsCopyPaste: function() {
+        return true;
     }
 });


### PR DESCRIPTION
This PR adds support for copying and pasting chatbox messages (both attachments and text messages). This is done by adding a simple popover which opens on right-clicking a chat bubble).

It only makes sense to be able to copy and paste certain chatbox messages, so a `supportsCopyPaste` method was added.

https://phabricator.endlessm.com/T14480