### PR TITLE
debian: Fix debian package

### DIFF
--- a/debian/coding-chatbox.install
+++ b/debian/coding-chatbox.install
@@ -1,5 +1,4 @@
 debian/tmp/usr/bin/com.endlessm.Coding.Chatbox
-debian/tmp/usr/lib/com.endlessm.Coding.Chatbox
 debian/tmp/usr/share/com.endlessm.Coding.Chatbox
 debian/tmp/usr/share/applications/com.endlessm.Coding.Chatbox.desktop
 debian/tmp/usr/share/icons/hicolor/64x64/apps/coding-chatbox.png


### PR DESCRIPTION
As the lib files are now handled by libcoding-chatbox, they should
not be included on the install file.