### PR TITLE
lib: add support for launching applications

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -442,7 +442,7 @@ const RenderableInputChatboxMessage = new Lang.Class({
 //
 // Helper function that returns content type of a GFile.
 function contentType(file){
-    let fileInfo = file.query_info('standard::*', 0, null, null);
+    let fileInfo = file.query_info('standard::content-type', 0, null, null);
     let type = fileInfo.get_content_type();
     return type;
 }
@@ -461,10 +461,10 @@ const RenderableAttachmentChatboxMessage = new Lang.Class({
             let appInfo = null;
 
             if (contentType(this.path) == 'application/x-desktop') {
-                appInfo = Gio.DesktopAppInfo.new_from_filename(this.path.get_parse_name());
+                appInfo = Gio.DesktopAppInfo.new_from_filename(this.path.get_path());
             } else {
                 appInfo = this.path.query_default_handler(null);
-                glist = [this.path];
+                glist.push([this.path]);
             }
             appInfo.launch(glist, null);
 


### PR DESCRIPTION
This enables us to launch applications by passing a path to an application .desktop file.
https://phabricator.endlessm.com/T14479

Notes:
- I tested it out, by calling it in the chatbox/views.js and passing it a path to an application .desktop file and seems to launch the application. Every once in a while I do get a segmentation fault (mainly if I handle errors) but not sure if it has anything to do with this. Maybe someone with more C knowledge can have a look.
- Not really clear on if I have to implement it in the views/main.js part, or will this be done as part of another ticket? The ticket didn't really say.
- For now I just included it in the `chatbox-utils`, let me know if you want it to be moved somewhere else.

@smspillaz @aperezdc can you have a look, thanks!
