### PR TITLE
main: Work around BGO 776645

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -748,10 +748,13 @@ const CodingChatboxMainWindow = new Lang.Class({
             return;
         }
 
-        row.snippet = body;
+        // Strip newlines from body to work around
+        // https://bugzilla.gnome.org/show_bug.cgi?id=776645
+        let stripped = body.replace('\n', ' ');
+        row.snippet = stripped;
 
         if (isNew) {
-            this.application.showNotification(title, body, row.avatar, actor);
+            this.application.showNotification(title, stripped, row.avatar, actor);
             row.highlight = true;
         }
     },


### PR DESCRIPTION
The 'lines' property does not have the effect we think it does
when linefeeds are added. Since we want to truncate this to just
one line, remove linefeeds before passing the string to row.snippet

https://phabricator.endlessm.com/T14797