### PR TITLE
views: Use a more naive regex method to strip <a> tags

### DIFF
--- a/src/views.js
+++ b/src/views.js
@@ -47,9 +47,11 @@ const Thumbnailer = (function() {
 
 // stripMarkup
 //
-// Strip pango markup from text
+// Strip pango markup from text. We also need to strip any embedded
+// links before passing to pango_parse_markup so that the latter does not
+// throw an error
 function stripMarkup(text) {
-    let escaped = GLib.markup_escape_text(text, -1);
+    let escaped = text.replace(/(<\/?\s*a.*?>)/g, '')
     return Pango.parse_markup(escaped, -1, '')[2];
 }
 


### PR DESCRIPTION
Using GLib.markup_escape_text will escape all markup, which is
precisely what we wanted to parse out.

https://phabricator.endlessm.com/T14966