### PR TITLE
Set NoDisplay to false in the desktop file

### DIFF
--- a/data/com.endlessm.Coding.Chatbox.desktop
+++ b/data/com.endlessm.Coding.Chatbox.desktop
@@ -8,3 +8,4 @@ Icon=coding-chatbox
 Categories=Utility;
 DBusActivatable=true
 StartupNotify=true
+NoDisplay=true


### PR DESCRIPTION
This will prevent ChatBox being available in the App Center
and on the Desktop. This is eos3.1 only and will be
overridden by a hook in the eos-image-builder coding.ini.

https://phabricator.endlessm.com/T15143