### PR TITLE
views: Use GnomeDesktopThumbnailFactory.lookup after saving thumb

### DIFF
--- a/src/views.js
+++ b/src/views.js
@@ -406,7 +406,7 @@ function getPreviewForFile(path, thumbnailFactory) {
                                     [],
                                     []);
                 } catch (e) {
-                    saveThumbnailError(targetThumbnailPath, uri, e);
+                    saveThumbnailError(thumbnailPath, uri, e);
                 }
             } else {
                 log('Failed to create thumbnail of ' + uri);

--- a/src/views.js
+++ b/src/views.js
@@ -304,8 +304,9 @@ function shouldThumbnail(uri, thumbnailFactory, mimeType, mtime) {
 //
 // Print error message when saving the thumbnail fails
 function saveThumbnailError(targetThumbnailPath, uri, e) {
-    log('Saving of thumbnail ' + targetThumbnailPath + ' for ' +
-        uri + ' failed: ' + String(e));
+    logError(e,
+             'Saving of thumbnail ' + targetThumbnailPath + ' for ' +
+             uri + ' failed');
 }
 
 // getPreviewForFile

--- a/src/views.js
+++ b/src/views.js
@@ -300,15 +300,6 @@ function shouldThumbnail(uri, thumbnailFactory, mimeType, mtime) {
            _THUMBNAIL_MIME_TYPES.indexOf(mimeType) !== -1;
 }
 
-// saveThumbnailError
-//
-// Print error message when saving the thumbnail fails
-function saveThumbnailError(targetThumbnailPath, uri, e) {
-    logError(e,
-             'Saving of thumbnail ' + targetThumbnailPath + ' for ' +
-             uri + ' failed');
-}
-
 // getPreviewForFile
 //
 // Get an object containing a reference to both a GIcon

--- a/src/views.js
+++ b/src/views.js
@@ -300,10 +300,6 @@ function shouldThumbnail(uri, thumbnailFactory, mimeType, mtime) {
            _THUMBNAIL_MIME_TYPES.indexOf(mimeType) !== -1;
 }
 
-function timevalToUsecs(timeval) {
-    return timeval.tv_sec * 1000000 + timeval.tv_usec;
-}
-
 // saveThumbnailError
 //
 // Print error message when saving the thumbnail fails


### PR DESCRIPTION
This will allow us to get the correctly sized thumbnail path
without having to resort to manually putting the thumbnail
in the right place. We also should have been calling this after
saving the thumbnail so that we could pass the right path
to the css.

https://phabricator.endlessm.com/T15359