### PR TITLE
ui: Use default-height and not height-request to set height

### DIFF
--- a/data/main.ui
+++ b/data/main.ui
@@ -3,7 +3,7 @@
   <requires lib="gtk+" version="3.10"/>
   <template class="Gjs_CodingChatboxMainWindow" parent="GtkApplicationWindow">
     <property name="can_focus">False</property>
-    <property name="height-request">800</property>
+    <property name="default-height">800</property>
     <child>
       <object class="GtkBox" id="vbox">
         <property name="can_focus">False</property>


### PR DESCRIPTION
This allows a user to resize a window to make it smaller.

https://phabricator.endlessm.com/T15639