### PR TITLE
views: Expand overlay inside of parent container

### DIFF
--- a/data/attachment-view.ui
+++ b/data/attachment-view.ui
@@ -26,6 +26,8 @@
                     <child>
                       <object class="GtkOverlay">
                         <property name="visible">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="halign">fill</propety>
                         <child>
                           <object class="GtkImage" id="attachment-icon">
                             <property name="visible">True</property>


### PR DESCRIPTION
This fixes an issue where the overlay just wasn't big enough
to cover the outside container.

https://phabricator.endlessm.com/T15495