### PR TITLE
ui: Fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,14 @@
 .libs
 Makefile
 Makefile.in
+
+/ABOUT-NLS
 /aclocal.m4
 /autom4te.cache
 /compile
 /config.guess
 /config.log
+/config.rpath
 /config.status
 /config.sub
 /configure
@@ -19,7 +22,11 @@ Makefile.in
 /install-sh
 /libtool
 /ltmain.sh
+/m4
 /missing
+/po
+/tap-driver.sh
+/test-driver
 
 /ChatboxService-1.0.gir
 /ChatboxService-1.0.typelib

--- a/data/attachment-view.ui
+++ b/data/attachment-view.ui
@@ -27,7 +27,7 @@
                       <object class="GtkOverlay">
                         <property name="visible">True</property>
                         <property name="hexpand">True</property>
-                        <property name="halign">fill</propety>
+                        <property name="halign">fill</property>
                         <child>
                           <object class="GtkImage" id="attachment-icon">
                             <property name="visible">True</property>


### PR DESCRIPTION
While building chatbox locally I noticed this typo, which prevented a successful build. 
Also updated `.gitignore`. 

Don't have a ticket, let me know if I should create one. 